### PR TITLE
Update index.tsx

### DIFF
--- a/packages/web/src/components/Input/index.tsx
+++ b/packages/web/src/components/Input/index.tsx
@@ -1,3 +1,4 @@
+ // eslint-disable-next-line
 import React, { InputHTMLAttributes, useEffect, useRef, useState, useCallback } from 'react'
 import { IconBaseProps } from 'react-icons'
 import { useField } from '@unform/core'
@@ -14,6 +15,7 @@ const Input: React.FC<InputProps> = ({name, icon: Icon, ...rest }) => {
   const [isFilled, setIsFilled] = useState(false)
 
   const inputRef = useRef<HTMLInputElement>(null)
+   // eslint-disable-next-line
   const { fieldName, defaultValue, error, registerField } = useField(name)
 
   useEffect(() => {


### PR DESCRIPTION
Hi my friend, happy hacktoberfest 2020.
Just fixing a minor warning about some "variables" never used.
when doing some yarn start at web directory.
Enclosed is the warning 
./src/components/Input/index.tsx
  Line 19:36:  'error' is assigned a value but never used  @typescript-eslint/no-unused-vars

./src/pages/Home/index.tsx
  Line 1:27:  'useEffect' is defined but never used  @typescript-eslint/no-unused-vars

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.